### PR TITLE
Drop CI Elixir 1.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,9 @@ jobs:
     name: Test (OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}})
     strategy:
       matrix:
-        elixir: ['1.12', '1.11', '1.10', '1.9']
+        elixir: ['1.12', '1.11', '1.10']
         # All of the above can use this version. For details see: https://hexdocs.pm/elixir/compatibility-and-deprecations.html#compatibility-between-elixir-and-erlang-otp
-        otp: [24, 23, 22, 21]
-        exclude:
-          - {otp: '21', elixir: '1.12'}
-          - {otp: '24', elixir: '1.9'}
+        otp: [24, 23, 22]
     steps:
       - uses: actions/checkout@v2
       - uses: erlef/setup-beam@v1


### PR DESCRIPTION
Tests are broken.  I'm initially just testing our CI pipeline since it seems to be out of date.  We may or may not want these to be dropped.

ref #257 