### PR TITLE
Correctly sets port in generated URLs

### DIFF
--- a/lib/jsonapi/view.ex
+++ b/lib/jsonapi/view.ex
@@ -284,6 +284,7 @@ defmodule JSONAPI.View do
     URI.to_string(%URI{
       scheme: scheme(conn),
       host: host(conn),
+      port: port(conn),
       path: Enum.join([view.namespace(), path_for(view)], "/")
     })
   end
@@ -292,6 +293,7 @@ defmodule JSONAPI.View do
     URI.to_string(%URI{
       scheme: scheme(conn),
       host: host(conn),
+      port: port(conn),
       path: Enum.join([view.namespace(), path_for(view), view.id(data)], "/")
     })
   end
@@ -362,6 +364,12 @@ defmodule JSONAPI.View do
 
   defp host(%Conn{host: host}),
     do: Application.get_env(:jsonapi, :host, host)
+
+  defp port(%Conn{port: 0} = conn),
+    do: port(%{conn | port: URI.default_port(scheme(conn))})
+
+  defp port(%Conn{port: port}),
+    do: Application.get_env(:jsonapi, :port, port)
 
   defp scheme(%Conn{scheme: scheme}),
     do: Application.get_env(:jsonapi, :scheme, to_string(scheme))

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule JSONAPI.Mixfile do
   def project do
     [
       app: :jsonapi,
-      version: "1.3.0",
+      version: "1.4.0",
       package: package(),
       compilers: compilers(Mix.env()),
       description: description(),

--- a/test/jsonapi/view_test.exs
+++ b/test/jsonapi/view_test.exs
@@ -89,6 +89,7 @@ defmodule JSONAPI.ViewTest do
       assert PostView.url_for([], nil) == "/api/posts"
       assert PostView.url_for(%{id: 1}, nil) == "/api/posts/1"
       assert PostView.url_for([], %Plug.Conn{}) == "http://www.example.com/api/posts"
+      assert PostView.url_for([], %Plug.Conn{port: 123}) == "http://www.example.com:123/api/posts"
       assert PostView.url_for(%{id: 1}, %Plug.Conn{}) == "http://www.example.com/api/posts/1"
 
       assert PostView.url_for_rel([], "comments", %Plug.Conn{}) ==
@@ -142,6 +143,29 @@ defmodule JSONAPI.ViewTest do
 
       assert PostView.url_for_rel(%{id: 1}, "comments", %Plug.Conn{}) ==
                "ftp://www.example.com/api/posts/1/relationships/comments"
+    end
+  end
+
+  describe "url_for/2 when port configured" do
+    setup do
+      Application.put_env(:jsonapi, :port, 42)
+
+      on_exit(fn ->
+        Application.delete_env(:jsonapi, :port)
+      end)
+
+      {:ok, []}
+    end
+
+    test "uses configured port instead of that on Conn" do
+      assert PostView.url_for([], %Plug.Conn{}) == "http://www.example.com:42/api/posts"
+      assert PostView.url_for(%{id: 1}, %Plug.Conn{}) == "http://www.example.com:42/api/posts/1"
+
+      assert PostView.url_for_rel([], "comments", %Plug.Conn{}) ==
+               "http://www.example.com:42/api/posts/relationships/comments"
+
+      assert PostView.url_for_rel(%{id: 1}, "comments", %Plug.Conn{}) ==
+               "http://www.example.com:42/api/posts/1/relationships/comments"
     end
   end
 


### PR DESCRIPTION
The url generation functions in JSONAPI.View did not previously allow the port
to be configured or allow the port to be correctly inferred from the Plug.Conn.
This change addresses both issues.

N.B., the default port on a Plug.Conn is set to 0. Since this can't possibly be
a valid port number, the url generation function will replace this with the
default port number for the scheme. This is likely only relevant in the test
cases, however.