### PR TITLE
Fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,14 +168,14 @@ you have any trouble with these deprecations please file an issue.
 
 ## v0.5.1 (2017-07-07)
 
-- [Added](https://github.com/jeregrine/jsonapi/commit/1f9e45aee4058ca6b3a8a55aaec6eebcada525a6) plug to make verifying reqeusts and their errors easier
+- [Added](https://github.com/jeregrine/jsonapi/commit/1f9e45aee4058ca6b3a8a55aaec6eebcada525a6) plug to make verifying requests and their errors easier
 
 ## v0.5.0 (2017-07-07)
 
 - [Added](https://github.com/jeregrine/jsonapi/commit/def022b327ac13e5e906a665321969b442048f3b) support for meta fields
 - [Added](https://github.com/jeregrine/jsonapi/commit/1bbe4de86baec250d0b8dcc263bb41a94dea8063) support for custom hosts
 - [Added](https://github.com/jeregrine/jsonapi/commit/3c73e870651f09ce8e09d4061111487db2e515f5) support for hidden attributes in views
-- [Added](https://github.com/jeregrine/jsonapi/commit/45f0d14e9d700d32a8b20dc04a4fa300fa43da37) support converstion of underscore to dashes.
+- [Added](https://github.com/jeregrine/jsonapi/commit/45f0d14e9d700d32a8b20dc04a4fa300fa43da37) support conversion of underscore to dashes.
 - [Fixed](https://github.com/jeregrine/jsonapi/commit/74b0d1914a3aceb792c753f2292002c10ac93005) issue with index.json
 - Now uses Credo
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Please see its documentation for details.
 
 JSONAPI has recommended in the past the use of dashes (`-`) in place of underscore (`_`) as a
 word separator for document member keys. However, as of [JSON API Spec (v1.1)](https://jsonapi.org/format/1.1/), it is now recommended that member names
-are camelCased. This library provides various configuration options for maximum flexibility including serializing outgoing parameters and deserializing incoming paramenters.
+are camelCased. This library provides various configuration options for maximum flexibility including serializing outgoing parameters and deserializing incoming parameters.
 
 Transforming fields requires two steps:
 

--- a/lib/jsonapi/exceptions.ex
+++ b/lib/jsonapi/exceptions.ex
@@ -1,7 +1,7 @@
 defmodule JSONAPI.Exceptions do
   defmodule InvalidQuery do
     @moduledoc """
-    Defines a generic exception for when an invalid query is recieved and is unable to be parsed nor handled.
+    Defines a generic exception for when an invalid query is received and is unable to be parsed nor handled.
 
     All JSONAPI exceptions on index routes return a 400.
     """

--- a/lib/jsonapi/view.ex
+++ b/lib/jsonapi/view.ex
@@ -99,7 +99,7 @@ defmodule JSONAPI.View do
   the serializer to *always* include if its loaded.
 
   ## Options
-    * `:host` (binary) - Allows the `host` to be overrided for generated URLs. Defaults to `host` of the supplied `conn`.
+    * `:host` (binary) - Allows the `host` to be overridden for generated URLs. Defaults to `host` of the supplied `conn`.
 
     * `:scheme` (atom) - Enables configuration of the HTTP scheme for generated URLS.  Defaults to `scheme` from the provided `conn`.
 


### PR DESCRIPTION
Found via `codespell -S deps,_build`