### PR TITLE
Response body for content type error

### DIFF
--- a/lib/jsonapi/error_view.ex
+++ b/lib/jsonapi/error_view.ex
@@ -83,6 +83,16 @@ defmodule JSONAPI.ErrorView do
     |> serialize_error
   end
 
+  @spec incorrect_content_type :: map()
+  def incorrect_content_type do
+    detail =
+      "The content-type header must use the media type '#{JSONAPI.mime_type()}'.  #{@crud_message}"
+
+    "Incorrect content-type"
+    |> build_error(415, detail)
+    |> serialize_error
+  end
+
   @spec send_error(Plug.Conn.t(), term()) :: term()
   def send_error(conn, %{errors: [%{status: status}]} = error),
     do: send_error(conn, status, error)

--- a/lib/jsonapi/plugs/content_type_negotiation.ex
+++ b/lib/jsonapi/plugs/content_type_negotiation.ex
@@ -52,7 +52,7 @@ defmodule JSONAPI.ContentTypeNegotiation do
         add_header_to_resp(conn)
 
       validate_header(content_type) == false ->
-        send_error(conn, 415)
+        send_error(conn, incorrect_content_type())
 
       validate_header(accepts) == false ->
         send_error(conn, 406)

--- a/test/jsonapi/plugs/content_type_negotiation_test.exs
+++ b/test/jsonapi/plugs/content_type_negotiation_test.exs
@@ -94,6 +94,9 @@ defmodule JSONAPI.ContentTypeNegotiationTest do
 
     assert conn.halted
     assert 415 == conn.status
+
+    assert conn.resp_body =~
+             ~s|The content-type header must use the media type 'application/vnd.api+json'|
   end
 
   test "halts and returns an error if content-type header contains other media type params" do


### PR DESCRIPTION
This PR adds a response body with a helpful error message when a request is rejected because of an invalid `content-type` header.

Because the `JSONAPI.ContentTypeNegotiation` has no logging, and was returning an empty body, it can be non-obvious to you and your users why their requests are being rejected with a 415.

