### PR TITLE
Adding ability to control rendering of relationships

### DIFF
--- a/lib/jsonapi/view.ex
+++ b/lib/jsonapi/view.ex
@@ -117,6 +117,7 @@ defmodule JSONAPI.View do
 
   @type t :: module()
   @type data :: any()
+  @type transformed_data :: any()
   @type field :: atom()
   @type links :: %{atom() => String.t()}
   @type meta :: %{atom() => String.t()}
@@ -130,6 +131,7 @@ defmodule JSONAPI.View do
   @callback hidden(data()) :: [field()]
   @callback links(data(), Conn.t()) :: links()
   @callback meta(data(), Conn.t()) :: meta() | nil
+  @callback relationship_data(data()) :: transformed_data() | nil
   @callback namespace() :: String.t()
   @callback pagination_links(data(), Conn.t(), Paginator.page(), Paginator.options()) ::
               Paginator.links()
@@ -188,6 +190,9 @@ defmodule JSONAPI.View do
 
       @impl View
       def meta(_data, _conn), do: nil
+
+      @impl View
+      def relationship_data(data), do: data
 
       @impl View
       if @namespace do


### PR DESCRIPTION
This allows us to workaround upstream bug 277, which is logged at https://github.com/beam-community/jsonapi/issues/277 Additionally, it gives full control over rendering the relationship if desired.

```
defmodule MyAppWeb.AuthorView do
  use JSONAPI.View, type: "authors"

  def fields do
    [:name]
  end

  # The addition of this new hook method allows us to override the rendering of the relationship.
  # In the below contrived example, we return `nil` for the relationship data if the id of the
  # resources is 37. Otherwise it passes through the data unchanged. It is important to be able to
  # return nil because it lets code higher up the call stack - encode_rel_data/2 - to cleanly detect
  # the nil and ultimately surface a { data: null } for the relationship in the response, which works
  # around https://github.com/beam-community/jsonapi/issues/277
  #
  def relationship_data(data) do
    case data.id do
      37 -> nil
    _ -> data
    end
  end
end
```