### PR TITLE
Update workflow to fix CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
   test:
     env:
       MIX_ENV: test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: Test (OTP ${{ matrix.otp }} / Elixir ${{ matrix.elixir }})
     strategy:
       matrix:
@@ -33,7 +33,7 @@ jobs:
       - run: mix test
 
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: Linting
     strategy:
       matrix:


### PR DESCRIPTION
`ubuntu-latest` is only documented as supporting OTP 24+ with the https://github.com/erlef/setup-beam GitHub Action. Let's stick with the next-to-latest ubuntu and continue testing a spectrum of OTP versions for now.