### PR TITLE
Update CI workflow to use main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, reopened, synchronize]
   push:
     branches:
-      - 'master'
+      - main
 
 jobs:
   test:
@@ -15,14 +15,14 @@ jobs:
     name: Test (OTP ${{ matrix.otp }} / Elixir ${{ matrix.elixir }})
     strategy:
       matrix:
-        elixir: ['1.13', '1.12', '1.11', '1.10']
+        elixir: ["1.13", "1.12", "1.11", "1.10"]
         # All of the above can use this version. For details see: https://hexdocs.pm/elixir/compatibility-and-deprecations.html#compatibility-between-elixir-and-erlang-otp
         otp: [25, 24, 23, 22]
         exclude:
-          - {otp: '24', elixir: '1.10'}
-          - {otp: '25', elixir: '1.10'}
-          - {otp: '25', elixir: '1.11'}
-          - {otp: '25', elixir: '1.12'}
+          - { otp: "24", elixir: "1.10" }
+          - { otp: "25", elixir: "1.10" }
+          - { otp: "25", elixir: "1.11" }
+          - { otp: "25", elixir: "1.12" }
     steps:
       - uses: actions/checkout@v2
       - uses: erlef/setup-beam@v1
@@ -37,7 +37,7 @@ jobs:
     name: Linting
     strategy:
       matrix:
-        elixir: ['1.13']
+        elixir: ["1.13"]
         otp: [25]
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Moving all the beam-community repos to `main` instead of `master` to align with larger industry shift. Updated CI and prettier applied.