### PR TITLE
Integration between UnderscoreParameters and QueryParser

### DIFF
--- a/lib/jsonapi/plugs/query_parser.ex
+++ b/lib/jsonapi/plugs/query_parser.ex
@@ -7,9 +7,9 @@ defmodule JSONAPI.QueryParser do
   import JSONAPI.Utils.String, only: [underscore: 1]
 
   @moduledoc """
-  Implements a fully JSONAPI V1 spec for parsing a complex query string and
-  returning Elixir datastructures. The purpose is to validate and encode incoming
-  queries and fail quickly.
+  Implements a fully JSONAPI V1 spec for parsing a complex query string via the
+  `query_params` field from a `Plug.Conn` struct and returning Elixir datastructures.
+  The purpose is to validate and encode incoming queries and fail quickly.
 
   Primarialy this handles:
     * [sorts](http://jsonapi.org/format/#fetching-sorting)
@@ -72,7 +72,8 @@ defmodule JSONAPI.QueryParser do
 
   Note that if your API is returning dasherized fields (e.g. `"dog-breed": "Corgi"`)
   we recommend that you include the `JSONAPI.UnderscoreParameters` Plug in your
-  API's pipeline. This will underscore fields for easier operations in your code.
+  API's pipeline with the `replace_query_params` option set to `true`. This will
+  underscore fields for easier operations in your code.
 
   For more details please see `JSONAPI.UnderscoreParameters`.
   """

--- a/lib/jsonapi/plugs/underscore_parameters.ex
+++ b/lib/jsonapi/plugs/underscore_parameters.ex
@@ -88,16 +88,16 @@ defmodule JSONAPI.UnderscoreParameters do
   def call(%Plug.Conn{params: params} = conn, opts) do
     content_type = get_req_header(conn, "content-type")
 
-    conn =
-      if opts[:replace_query_params] == true do
-        query_params = fetch_query_params(conn).query_params
-        new_query_params = JString.expand_fields(query_params, &JString.underscore/1)
-        Map.put(conn, :query_params, new_query_params)
-      else
-        conn
-      end
-
     if JSONAPI.mime_type() in content_type do
+      conn =
+        if opts[:replace_query_params] do
+          query_params = fetch_query_params(conn).query_params
+          new_query_params = JString.expand_fields(query_params, &JString.underscore/1)
+          Map.put(conn, :query_params, new_query_params)
+        else
+          conn
+        end
+
       new_params = JString.expand_fields(params, &JString.underscore/1)
       Map.put(conn, :params, new_params)
     else

--- a/lib/jsonapi/plugs/underscore_parameters.ex
+++ b/lib/jsonapi/plugs/underscore_parameters.ex
@@ -88,16 +88,16 @@ defmodule JSONAPI.UnderscoreParameters do
   def call(%Plug.Conn{params: params} = conn, opts) do
     content_type = get_req_header(conn, "content-type")
 
-    if JSONAPI.mime_type() in content_type do
-      conn =
-        if opts[:replace_query_params] do
-          query_params = fetch_query_params(conn).query_params
-          new_query_params = JString.expand_fields(query_params, &JString.underscore/1)
-          Map.put(conn, :query_params, new_query_params)
-        else
-          conn
-        end
+    conn =
+      if opts[:replace_query_params] == true do
+        query_params = fetch_query_params(conn).query_params
+        new_query_params = JString.expand_fields(query_params, &JString.underscore/1)
+        Map.put(conn, :query_params, new_query_params)
+      else
+        conn
+      end
 
+    if JSONAPI.mime_type() in content_type do
       new_params = JString.expand_fields(params, &JString.underscore/1)
       Map.put(conn, :params, new_params)
     else

--- a/lib/jsonapi/plugs/underscore_parameters.ex
+++ b/lib/jsonapi/plugs/underscore_parameters.ex
@@ -1,12 +1,24 @@
 defmodule JSONAPI.UnderscoreParameters do
   @moduledoc """
-  Takes dasherized JSON:API params and deserializes them to underscored params. Add
+  Takes dasherized JSON:API params and converts them to underscored params. Add
   this to your API's pipeline to aid in dealing with incoming parameters such as query
   params or data.
+
+  By default the newly underscored params will replace the existing `params` field of the
+  `Plug.Conn` struct, but leave the `query_params` and `body_params` untouched.  If you
+  are using the `JSONAPI.QueryParser` and need to have the `query_params` on the
+  `Plug.Conn` updated, set the `replace_query_params` option to `true`.
 
   Note that this Plug will only underscore parameters when the request's content
   type is for a JSON:API request (i.e. "application/vnd.api+json"). All other
   content types will be ignored.
+
+  ## Options
+
+    * `:replace_query_params` - When `true`, it will replace the `query_params` field in
+    the `Plug.Conn` struct.  This is useful when you have downstream code which is
+    expecting underscored fields in `query_params`, and not just in `params`. Defaults
+    to `false`.
 
   ## Example
 
@@ -55,15 +67,38 @@ defmodule JSONAPI.UnderscoreParameters do
   alias JSONAPI.Utils.String, as: JString
 
   @doc false
-  def init(opts), do: opts
+  def init(opts) do
+    opt = Keyword.fetch(opts, :replace_query_params)
+
+    if match?({:ok, b} when not is_boolean(b), opt) do
+      raise ArgumentError,
+        message: """
+        The :replace_query_params option must be a boolean.  Example:
+
+        pipeline :api do
+          plug JSONAPI.UnderscoreParameters, replace_query_params: true
+        end
+        """
+    else
+      opts
+    end
+  end
 
   @doc false
-  def call(%Plug.Conn{params: params} = conn, _opts) do
+  def call(%Plug.Conn{params: params} = conn, opts) do
     content_type = get_req_header(conn, "content-type")
 
     if JSONAPI.mime_type() in content_type do
-      new_params = JString.expand_fields(params, &JString.underscore/1)
+      conn =
+        if opts[:replace_query_params] do
+          query_params = fetch_query_params(conn).query_params
+          new_query_params = JString.expand_fields(query_params, &JString.underscore/1)
+          Map.put(conn, :query_params, new_query_params)
+        else
+          conn
+        end
 
+      new_params = JString.expand_fields(params, &JString.underscore/1)
       Map.put(conn, :params, new_params)
     else
       conn

--- a/lib/jsonapi/plugs/underscore_parameters.ex
+++ b/lib/jsonapi/plugs/underscore_parameters.ex
@@ -4,10 +4,10 @@ defmodule JSONAPI.UnderscoreParameters do
   this to your API's pipeline to aid in dealing with incoming parameters such as query
   params or data.
 
-  By default the newly underscored params will replace the existing `params` field of the
-  `Plug.Conn` struct, but leave the `query_params` and `body_params` untouched.  If you
-  are using the `JSONAPI.QueryParser` and need to have the `query_params` on the
-  `Plug.Conn` updated, set the `replace_query_params` option to `true`.
+  By default the newly underscored params will only replace the existing `params` field
+  of the `Plug.Conn` struct, but leave the `query_params` and `body_params` untouched.
+  If you are using the `JSONAPI.QueryParser` and need to also have the `query_params` on
+  the `Plug.Conn` updated, set the `replace_query_params` option to `true`.
 
   Note that this Plug will only underscore parameters when the request's content
   type is for a JSON:API request (i.e. "application/vnd.api+json"). All other

--- a/test/jsonapi/plugs/query_parser_test.exs
+++ b/test/jsonapi/plugs/query_parser_test.exs
@@ -156,10 +156,7 @@ defmodule JSONAPI.QueryParserTest do
 
   test "integrates with UnderscoreParameters to filter dasherized fields" do
     # The incoming request has a dasherized filter name
-    conn =
-      :get
-      |> conn("?filter[favorite-food]=pizza")
-      |> put_req_header("content-type", JSONAPI.mime_type())
+    conn = conn(:get, "?filter[favorite-food]=pizza")
 
     # The filter in the controller is expecting an underscored filter name
     config = struct(Config, view: MyView, opts: [filter: ["favorite_food"]])

--- a/test/jsonapi/plugs/query_parser_test.exs
+++ b/test/jsonapi/plugs/query_parser_test.exs
@@ -156,7 +156,10 @@ defmodule JSONAPI.QueryParserTest do
 
   test "integrates with UnderscoreParameters to filter dasherized fields" do
     # The incoming request has a dasherized filter name
-    conn = conn(:get, "?filter[favorite-food]=pizza")
+    conn =
+      :get
+      |> conn("?filter[favorite-food]=pizza")
+      |> put_req_header("content-type", JSONAPI.mime_type())
 
     # The filter in the controller is expecting an underscored filter name
     config = struct(Config, view: MyView, opts: [filter: ["favorite_food"]])

--- a/test/jsonapi/plugs/underscore_parameters_test.exs
+++ b/test/jsonapi/plugs/underscore_parameters_test.exs
@@ -4,89 +4,123 @@ defmodule JSONAPI.UnderscoreParametersTest do
 
   alias JSONAPI.UnderscoreParameters
 
-  test "underscores dasherized data parameters" do
-    params = %{
-      "data" => %{
-        "attributes" => %{
-          "first-name" => "John",
-          "last-name" => "Cleese",
-          "stats" => %{
-            "age" => 45,
-            "dog-name" => "Pedro"
+  describe "call/2" do
+    test "underscores dasherized data parameters" do
+      params = %{
+        "data" => %{
+          "attributes" => %{
+            "first-name" => "John",
+            "last-name" => "Cleese",
+            "stats" => %{
+              "age" => 45,
+              "dog-name" => "Pedro"
+            }
           }
-        }
-      },
-      "filter" => %{
-        "dog-breed" => "Corgi"
-      }
-    }
-
-    conn =
-      :get
-      |> conn("/hello", params)
-      |> put_req_header("content-type", JSONAPI.mime_type())
-
-    assert %Plug.Conn{
-             params: %{
-               "data" => %{
-                 "attributes" => %{
-                   "first_name" => "John",
-                   "last_name" => "Cleese",
-                   "stats" => %{
-                     "age" => "45",
-                     "dog_name" => "Pedro"
-                   }
-                 }
-               },
-               "filter" => %{
-                 "dog_breed" => "Corgi"
-               }
-             }
-           } = UnderscoreParameters.call(conn, [])
-
-    params = %{
-      "data" => %{
-        "attributes" => %{
-          "math-problem" => "1-1=2"
-        }
-      }
-    }
-
-    conn =
-      :get
-      |> conn("/example", params)
-      |> put_req_header("content-type", JSONAPI.mime_type())
-
-    assert %Plug.Conn{
-             params: %{
-               "data" => %{
-                 "attributes" => %{
-                   "math_problem" => "1-1=2"
-                 }
-               }
-             }
-           } = UnderscoreParameters.call(conn, [])
-  end
-
-  test "does not transform when the content type is not for json:api" do
-    params = %{
-      "data" => %{
-        "attributes" => %{
+        },
+        "filter" => %{
           "dog-breed" => "Corgi"
         }
       }
-    }
 
-    conn = conn(:get, "/hello", params)
+      conn =
+        :get
+        |> conn("/hello", params)
+        |> put_req_header("content-type", JSONAPI.mime_type())
 
-    assert %Plug.Conn{
-             params: %{
-               "data" => %{
-                 "attributes" => %{
-                   "dog-breed" => "Corgi"
+      assert %Plug.Conn{
+               params: %{
+                 "data" => %{
+                   "attributes" => %{
+                     "first_name" => "John",
+                     "last_name" => "Cleese",
+                     "stats" => %{
+                       "age" => "45",
+                       "dog_name" => "Pedro"
+                     }
+                   }
+                 },
+                 "filter" => %{
+                   "dog_breed" => "Corgi"
                  }
                }
-             }
-           } = UnderscoreParameters.call(conn, [])
+             } = UnderscoreParameters.call(conn, [])
+
+      params = %{
+        "data" => %{
+          "attributes" => %{
+            "math-problem" => "1-1=2"
+          }
+        }
+      }
+
+      conn =
+        :get
+        |> conn("/example", params)
+        |> put_req_header("content-type", JSONAPI.mime_type())
+
+      assert %Plug.Conn{
+               params: %{
+                 "data" => %{
+                   "attributes" => %{
+                     "math_problem" => "1-1=2"
+                   }
+                 }
+               }
+             } = UnderscoreParameters.call(conn, [])
+    end
+
+    test ":replace_query_params option replaces in the Conn's query_params" do
+      conn =
+        :get
+        |> conn("?filter[favorite-food]=pizza")
+        |> put_req_header("content-type", JSONAPI.mime_type())
+
+      # Before: filter name is dasherized
+      assert %{"favorite-food" => _} = fetch_query_params(conn).query_params["filter"]
+
+      # After: filter name is underscored
+      updated_conn = UnderscoreParameters.call(conn, replace_query_params: true)
+      assert %{"favorite_food" => _} = fetch_query_params(updated_conn).query_params["filter"]
+
+      # After (without option): filter name remains dasherized
+      updated_conn = UnderscoreParameters.call(conn, [])
+      assert %{"favorite-food" => _} = fetch_query_params(updated_conn).query_params["filter"]
+    end
+
+    test "does not transform when the content type is not for json:api" do
+      params = %{
+        "data" => %{
+          "attributes" => %{
+            "dog-breed" => "Corgi"
+          }
+        }
+      }
+
+      conn = conn(:get, "/hello", params)
+
+      assert %Plug.Conn{
+               params: %{
+                 "data" => %{
+                   "attributes" => %{
+                     "dog-breed" => "Corgi"
+                   }
+                 }
+               }
+             } = UnderscoreParameters.call(conn, [])
+    end
+  end
+
+  describe "init/1" do
+    test "the replace_query_params option must be a boolean" do
+      # These are okay
+      assert UnderscoreParameters.init([])
+      assert UnderscoreParameters.init(replace_query_params: true)
+      assert UnderscoreParameters.init(replace_query_params: false)
+
+      # This is not allowed
+      assert_raise ArgumentError, fn ->
+        UnderscoreParameters.init(replace_query_params: 1)
+      end
+    end
   end
 end

--- a/test/jsonapi/plugs/underscore_parameters_test.exs
+++ b/test/jsonapi/plugs/underscore_parameters_test.exs
@@ -70,10 +70,7 @@ defmodule JSONAPI.UnderscoreParametersTest do
     end
 
     test ":replace_query_params option replaces in the Conn's query_params" do
-      conn =
-        :get
-        |> conn("?filter[favorite-food]=pizza")
-        |> put_req_header("content-type", JSONAPI.mime_type())
+      conn = conn(:get, "?filter[favorite-food]=pizza")
 
       # Before: filter name is dasherized
       assert %{"favorite-food" => _} = fetch_query_params(conn).query_params["filter"]

--- a/test/jsonapi/plugs/underscore_parameters_test.exs
+++ b/test/jsonapi/plugs/underscore_parameters_test.exs
@@ -70,7 +70,10 @@ defmodule JSONAPI.UnderscoreParametersTest do
     end
 
     test ":replace_query_params option replaces in the Conn's query_params" do
-      conn = conn(:get, "?filter[favorite-food]=pizza")
+      conn =
+        :get
+        |> conn("?filter[favorite-food]=pizza")
+        |> put_req_header("content-type", JSONAPI.mime_type())
 
       # Before: filter name is dasherized
       assert %{"favorite-food" => _} = fetch_query_params(conn).query_params["filter"]

--- a/test/jsonapi/plugs/underscore_parameters_test.exs
+++ b/test/jsonapi/plugs/underscore_parameters_test.exs
@@ -117,9 +117,13 @@ defmodule JSONAPI.UnderscoreParametersTest do
       assert UnderscoreParameters.init(replace_query_params: true)
       assert UnderscoreParameters.init(replace_query_params: false)
 
-      # This is not allowed
+      # These are not allowed
       assert_raise ArgumentError, fn ->
         UnderscoreParameters.init(replace_query_params: 1)
+      end
+
+      assert_raise ArgumentError, fn ->
+        UnderscoreParameters.init(foo: "bar", replace_query_params: 1)
       end
     end
   end


### PR DESCRIPTION
The Problem:

If you are using the `UnderscoreParameters` plug, followed by filtering with the `QueryParser` plug, the filtering will not work.  Here is an example:

```elixir
# router.ex

pipeline :api do
  plug JSONAPI.EnsureSpec
  plug JSONAPI.Deserializer
  plug JSONAPI.UnderscoreParameters
end
```

```elixir
# foobar_controller.ex

plug JSONAPI.QueryParser,
  filter: ~w(underscored_field_name),
  view: FoobarView
```

The expectation is that I can make the following request, and have the dasherized field in my query string be converted to underscores by the time it hits the controller:

```
GET /foobar?filter[underscored-field-name]=whatever
```

**The reason it doesn't work is** because the `UnderscoreParameters` plug replaces the `params` field of the `Plug.Conn`, but the subsequent `QueryParser` is checking in the `query_params` field instead.

---

The solution:

This PR adds support for an opt-in option on the `UnderscoreParameters` plug called `replace_query_params`.  It is opt-in so that nothing breaks for existing users.  When you set the option to `true` the `query_params` will be replaced on the `Plug.Conn`, not just the `params`.  

```elixir
# router.ex

pipeline :api do
  plug JSONAPI.EnsureSpec
  plug JSONAPI.Deserializer
  plug JSONAPI.UnderscoreParameters, replace_query_params: true # <--- this will make things work
end
```