### PR TITLE
Only underscore field[...] values

### DIFF
--- a/lib/jsonapi/plugs/underscore_parameters.ex
+++ b/lib/jsonapi/plugs/underscore_parameters.ex
@@ -89,6 +89,8 @@ defmodule JSONAPI.UnderscoreParameters do
     content_type = get_req_header(conn, "content-type")
 
     if JSONAPI.mime_type() in content_type do
+      # In version 2.0, when this block is no longer conditional and applies every time, ensure
+      # that we apply the same treatment to the query_params and "regular" params.
       conn =
         if opts[:replace_query_params] do
           query_params = fetch_query_params(conn).query_params


### PR DESCRIPTION
**The Problem**

If you pass in query parameters like this: `?fields[my-type]=field-abc` and used the `replace_query_params: true` option, then the results would look like:

```elixir
%{"fields" => %{"my_type" => "field-abc"}}
```

However, the results we actually wanted were this:

```elixir
%{"fields" => %{"my-type" => "field_abc"}}
```

Where the type remains unchanged to match the kebab-case type in the view, and the field gets underscored to match the field name in the Elixir codebase:

```elixir
defmodule MyTypeView do
  def type, do: "my-type"
  
  def fields, do: [:field_abc]
end
```

**The Solution**

The fix is to be a little more precise in the `UnderscoreParameters` plug.  If the `fields` query parameter exists, ensure that we do not change the keys, but do change the values.