### PR TITLE
Show NotLoaded Relationship IDs

### DIFF
--- a/test/jsonapi/serializer_test.exs
+++ b/test/jsonapi/serializer_test.exs
@@ -294,6 +294,46 @@ defmodule JSONAPI.SerializerTest do
     assert Enum.count(encoded[:included]) == 1
   end
 
+  test "serialize handles NotLoaded relationships" do
+    data = %{
+      id: 1,
+      text: "Hello",
+      body: "Hello world",
+      author_id: 2,
+      author: %{
+        __struct__: Ecto.Association.NotLoaded,
+        __field__: :author,
+        __cardinality__: :one
+      },
+      best_comments: %{
+        __struct__: Ecto.Association.NotLoaded,
+        __field__: :best_comments,
+        __cardinality__: :many
+      }
+    }
+
+    relationships = Serializer.serialize(PostView, data, nil)[:data][:relationships]
+
+    assert relationships == %{
+             author: %{
+               data: %{
+                 id: 2,
+                 type: "user"
+               },
+               links: %{
+                 related: "/user/2",
+                 self: "/mytype/1/relationships/author"
+               }
+             },
+             best_comments: %{
+               links: %{
+                 related: "/comment/",
+                 self: "/mytype/1/relationships/best_comments"
+               }
+             }
+           }
+  end
+
   test "serialize handles a nil relationship" do
     data = %{
       id: 1,


### PR DESCRIPTION
**The Problem**

Currently, it is not possible to view _any_ information about a relationship unless you `include` it.  If you do not use the `include` query parameter, the `relationships` will be an empty map, not even showing what relationships are possible:

```
GET  /foobar/25
{
  "data": {
    "attributes": {...},
    "id": "25",
    "links": {
      "self": "https://example.com/foobars/25"
    },
    "relationships": {}, // <----- This is always empty
    "type": "foobars"
  }
}
```

The work around for this is to `include` relationships to check for their existence.  Unfortunately this is expensive because it generates additional `JOIN` queries.

---

**This PR**

Without doing any additional queries, we can attach information we already have about a relationships, like the `id`:

```
GET  /foobar/25

{
  "data": {
    "attributes": {...},
    "id": "25",
    "links": {
      "self": "https://example.com/foobars/25"
    },
    "relationships": { // <---- There is now data here about the relationship
      "foo": {
        "id": "354",
        "type": "foos"
      }
    },
    "type": "foobars"
  }
}
```

This is possible because even though the `Foobar` model would have a `NotLoaded` value for `foo`, there should still be a foreign key present on the model that we can use to populate the ID and links:

```elixir
%Foobar{
  foo_id: 354, # <--- We can use this, even though the foo is not loaded
  foo: #Ecto.Association.NotLoaded<association :foo is not loaded>
}
```

---

Discussion Points:

- [ ] Should this be behind a config flag?
- [ ] Should we be more precise when looding foreign key (see code annotation)