### PR TITLE
Add support for a JSON:API includes allowlist.

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule JSONAPI.Mixfile do
   def project do
     [
       app: :jsonapi,
-      version: "1.5.1",
+      version: "1.6.0",
       package: package(),
       compilers: compilers(Mix.env()),
       description: description(),

--- a/test/jsonapi/plugs/query_parser_test.exs
+++ b/test/jsonapi/plugs/query_parser_test.exs
@@ -108,6 +108,18 @@ defmodule JSONAPI.QueryParserTest do
     end
   end
 
+  test "parse_include/2 errors with limited allowed includes" do
+    config = struct(Config, view: MyView, opts: [include: ~w(author comments comments.user)])
+
+    assert_raise InvalidQuery, "invalid include, best_friends for type mytype", fn ->
+      parse_include(config, "best_friends,author")
+    end
+
+    assert parse_include(config, "author,comments").include == [:author, :comments]
+
+    assert parse_include(config, "author,comments.user").include == [:author, {:comments, :user}]
+  end
+
   test "parse_fields/2 turns a fields map into a map of validated fields" do
     config = struct(Config, view: MyView)
     assert parse_fields(config, %{"mytype" => "id,text"}).fields == %{"mytype" => [:id, :text]}


### PR DESCRIPTION
This PR makes it possible to restrict the allowed includes to a specified list instead of allowing all relationships to be included. This kind of behavior has been needed by Opal Labs on several occasions for a few reasons, most notably when writing an endpoint on service `A` that has a relationship to resource owned by service `B` and not wanting to support including resources from service `B` in service `A`'s responses.