### PR TITLE
Change camelize behavior

### DIFF
--- a/lib/jsonapi/utils/string.ex
+++ b/lib/jsonapi/utils/string.ex
@@ -94,6 +94,9 @@ defmodule JSONAPI.Utils.String do
       iex> camelize("")
       ""
 
+      iex> camelize("alreadyCamelized")
+      "alreadyCamelized"
+
   """
   @spec camelize(atom) :: String.t()
   def camelize(value) when is_atom(value) do
@@ -111,10 +114,18 @@ defmodule JSONAPI.Utils.String do
              ~r{(?<=[a-zA-Z0-9])[-_](?=[a-zA-Z0-9])},
              to_string(value)
            ) do
-      [h | t] = words |> Enum.filter(&(&1 != ""))
+      tokens = Enum.filter(words, &(&1 != ""))
 
-      [String.downcase(h) | camelize_list(t)]
-      |> Enum.join()
+      case tokens do
+        # If there is only one token, leave it as-is
+        [token] ->
+          token
+
+        # If there are multiple tokens, perform the camelizing
+        [h | t] ->
+          [String.downcase(h) | camelize_list(t)]
+          |> Enum.join()
+      end
     end
   end
 

--- a/lib/jsonapi/utils/string.ex
+++ b/lib/jsonapi/utils/string.ex
@@ -112,16 +112,15 @@ defmodule JSONAPI.Utils.String do
     with words <-
            Regex.split(
              ~r{(?<=[a-zA-Z0-9])[-_](?=[a-zA-Z0-9])},
-             to_string(value)
+             to_string(value),
+             trim: true
            ) do
-      tokens = Enum.filter(words, &(&1 != ""))
+      case words do
+        # If there is only one word, leave it as-is
+        [word] ->
+          word
 
-      case tokens do
-        # If there is only one token, leave it as-is
-        [token] ->
-          token
-
-        # If there are multiple tokens, perform the camelizing
+        # If there are multiple words, perform the camelizing
         [h | t] ->
           [String.downcase(h) | camelize_list(t)]
           |> Enum.join()

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule JSONAPI.Mixfile do
   def project do
     [
       app: :jsonapi,
-      version: "1.5.0",
+      version: "1.5.1",
       package: package(),
       compilers: compilers(Mix.env()),
       description: description(),


### PR DESCRIPTION
👋 I have a view which has a field which I treat as an "opaque object" which I store as a `map`.  Something like this:

```elixir
defmodule MyApp.Foobar do

  # ...
  schema "foobars" do
    field :location, :map
  end
end
```

```elixir
defmodule MyAppWeb.FoobarView do
  use JSONAPI.View, type: "foobars"

  def fields do
    [
      :location
    ]
  end
end
```

In my postgres database, an example value looks something like (note the camelCased `localizedAddress` field):
```json
{
  "country": "China",
  "localizedAddress": null
}
```

The problem is that after this data flows out of my view, the resulting payload looks like this, where the  `localizedAddress` key has become `localizedaddress`:

```json
{
    "data": {
        "attributes": {
            "location": {
                "country": "China",
                "localizedaddress": null
            }
        }
    }
}
```

---

I have pinned it down to the `String` module:

```elixir
iex(1)> JSONAPI.Utils.String.camelize("localizedAddress")
"localizedaddress"
```

---

If changing the `String` module is too disruptive/risky, then I think there should be a new callback in the view that is a mechanism for giving a value for a field, but without any further transformations applied to it.  I.e. today if I do this:

```elixir
defmodule MyAppWeb.FoobarView do
  use JSONAPI.View, type: "foobars"

  def fields do
    [
      :location
    ]
  end
  
  # This doesn't work: whatever I do here doesn't matter because the downstream string module will still make its changes
  def location(%{location: location}, _conn) do
    location
  end

  # Maybe something like this, but with a better name
  def location_value(%{location: location}, _conn) do
    location
  end
end
```