### PR TITLE
Fix relationships spec & external relationship use-case

### DIFF
--- a/lib/jsonapi/serializer.ex
+++ b/lib/jsonapi/serializer.ex
@@ -79,7 +79,7 @@ defmodule JSONAPI.Serializer do
   @spec encode_relationships(Conn.t(), document(), tuple(), list()) :: tuple()
   def encode_relationships(conn, doc, {view, data, _, _} = view_info, options) do
     view.relationships()
-    |> Enum.filter(&data_loaded?(Map.get(data, get_data_key(&1))))
+    |> Enum.filter(&assoc_loaded?(Map.get(data, get_data_key(&1))))
     |> Enum.map_reduce(doc, &build_relationships(conn, view_info, &1, &2, options))
   end
 

--- a/lib/jsonapi/view.ex
+++ b/lib/jsonapi/view.ex
@@ -150,7 +150,7 @@ defmodule JSONAPI.View do
   @callback pagination_links(data(), Conn.t(), Paginator.page(), Paginator.options()) ::
               Paginator.links()
   @callback path() :: String.t() | nil
-  @callback relationships() :: [{atom(), t() | {t(), :include}}]
+  @callback relationships() :: [{atom(), t() | {t(), :include} | {atom(), t()} | {atom(), t(), :include}}]
   @callback type() :: resource_type()
   @callback url_for(data(), Conn.t() | nil) :: String.t()
   @callback url_for_pagination(data(), Conn.t(), Paginator.params()) :: String.t()

--- a/lib/jsonapi/view.ex
+++ b/lib/jsonapi/view.ex
@@ -150,7 +150,9 @@ defmodule JSONAPI.View do
   @callback pagination_links(data(), Conn.t(), Paginator.page(), Paginator.options()) ::
               Paginator.links()
   @callback path() :: String.t() | nil
-  @callback relationships() :: [{atom(), t() | {t(), :include} | {atom(), t()} | {atom(), t(), :include}}]
+  @callback relationships() :: [
+              {atom(), t() | {t(), :include} | {atom(), t()} | {atom(), t(), :include}}
+            ]
   @callback type() :: resource_type()
   @callback url_for(data(), Conn.t() | nil) :: String.t()
   @callback url_for_pagination(data(), Conn.t(), Paginator.params()) :: String.t()


### PR DESCRIPTION
The features of https://github.com/beam-community/jsonapi/pull/270 were broken in two ways that this PR fixes.

1. The `@spec` for the `relationships` `callback` for `JSONAPI.View` actually did not allow for the various new structures a `relationships` callback is allowed to return under the above PR.
2. The PR was intended to support (among other more general purposes) remapping of an attribute field to a relationship -- this is niche, but sometimes quite useful. The above PR and its tests failed to fully realize that goal by missing one small detail (lost in a merge conflict resolution, as it turns out).

This PR fixes both of these problems and adds test coverage for the latter.