### PR TITLE
Format required checks for relationships

### DIFF
--- a/lib/jsonapi/plugs/format_required.ex
+++ b/lib/jsonapi/plugs/format_required.ex
@@ -12,6 +12,57 @@ defmodule JSONAPI.FormatRequired do
 
   def call(%{method: method} = conn, _opts) when method in ~w[DELETE GET HEAD], do: conn
 
+  def call(
+        %{method: "POST", params: %{"data" => %{"type" => _, "relationships" => relationships}}} =
+          conn,
+        _
+      )
+      when not is_map(relationships) do
+    send_error(conn, relationships_create_missing_object())
+  end
+
+  def call(
+        %{
+          method: "POST",
+          params: %{"data" => %{"type" => _, "relationships" => relationships}}
+        } = conn,
+        _
+      )
+      when is_map(relationships) do
+    errors =
+      Enum.reduce(relationships, [], fn
+        {_relationship_name, %{"data" => %{"type" => _type, "id" => _}}}, acc ->
+          acc
+
+        {relationship_name, %{"data" => %{"type" => _type}}}, acc ->
+          error = missing_relationship_data_id_param_error(relationship_name)
+          [error | acc]
+
+        {relationship_name, %{"data" => %{"id" => _type}}}, acc ->
+          error = missing_relationship_data_type_param_error(relationship_name)
+          [error | acc]
+
+        {relationship_name, %{"data" => %{}}}, acc ->
+          id_error = missing_relationship_data_id_param_error(relationship_name)
+          type_error = missing_relationship_data_type_param_error(relationship_name)
+          [id_error | [type_error | acc]]
+
+        {_relationship_name, %{"data" => _}}, acc ->
+          # Allow things other than resource identifier objects per https://jsonapi.org/format/#document-resource-object-linkage
+          acc
+
+        {relationship_name, _}, acc ->
+          error = missing_relationship_data_param_error(relationship_name)
+          [error | acc]
+      end)
+
+    if Enum.empty?(errors) do
+      conn
+    else
+      send_error(conn, serialize_errors(errors))
+    end
+  end
+
   def call(%{method: "POST", params: %{"data" => %{"type" => _}}} = conn, _), do: conn
 
   def call(%{method: method, params: %{"data" => [%{"type" => _} | _]}} = conn, _)


### PR DESCRIPTION
This PR updates the JSON:API format verification plug to include checks for the relationships key when POST-ing to create a new resource.

This is intended to help address: https://github.com/beam-community/jsonapi/issues/294

Additionally this PR:
1. Adjusts the list behavior in `ErrorView.send_error/2` because I don't think it extracted the status code previously
2. Added support for serializing a list of formatting errors to handle multiple malformed relationship entries