### PR TITLE
Nested query filters

### DIFF
--- a/lib/jsonapi/utils/list.ex
+++ b/lib/jsonapi/utils/list.ex
@@ -18,6 +18,8 @@ defmodule JSONAPI.Utils.List do
       iex> to_list_of_query_string_components(%{"filters" => %{"age" => 18, "name" => "John"}})
       [{"filters[age]", 18}, {"filters[name]", "John"}]
 
+      iex> to_list_of_query_string_components(%{"filter" => %{"age" => 18, "car" => %{"make" => "honda", "model" => "civic"}}})
+      [{"filter[age]", 18}, {"filter[car][make]", "honda"}, {"filter[car][model]", "civic"}]
   """
   @spec to_list_of_query_string_components(map()) :: list(tuple())
   def to_list_of_query_string_components(map) when is_map(map) do
@@ -29,7 +31,9 @@ defmodule JSONAPI.Utils.List do
   end
 
   defp do_to_list_of_query_string_components({key, value}) when is_map(value) do
-    Enum.flat_map(value, fn {k, v} -> to_list_of_two_elem_tuple("#{key}[#{k}]", v) end)
+    Enum.flat_map(value, fn {k, v} ->
+      do_to_list_of_query_string_components({"#{key}[#{k}]", v})
+    end)
   end
 
   defp do_to_list_of_query_string_components({key, value}),


### PR DESCRIPTION
According to the spec, you can filter on included resources by doing something like:

```
/people?filter[car][make]=honda
```

When I try a request like this, everything works besides for the construction of the pagination urls.

This PR fixes the `Utils.List.to_list_of_query_string_components/1` function so that its output is valid for the `URI.encode_query/1` function.

---
Before this PR:

```elixir
iex(1)> %{"filter" => %{"car" => %{"make" => "honda", "model" => "civic"}}} |> JSONAPI.Utils.List.to_list_of_query_string_components() |> URI.encode_query()
** (Protocol.UndefinedError) protocol String.Chars not implemented for %{"make" => "honda", "model" => "civic"} of type Map. This protocol is implemented for the following type(s): Atom, BitString, Cldr.Calendar.Duration, Cldr.Currency, Cldr.LanguageTag, Cldr.LanguageTag.T, Cldr.LanguageTag.U, Date, DateTime, Decimal, Float, Hex.Solver.Assignment, Hex.Solver.Constraints.Empty, Hex.Solver.Constraints.Range, Hex.Solver.Constraints.Union, Hex.Solver.Incompatibility, Hex.Solver.PackageRange, Hex.Solver.Term, Integer, List, NaiveDateTime, OpenApiSpex.Cast.Error, Phoenix.LiveComponent.CID, Postgrex.Copy, Postgrex.Query, Time, URI, Version, Version.Requirement
    (elixir 1.14.3) lib/string/chars.ex:3: String.Chars.impl_for!/1
    (elixir 1.14.3) lib/string/chars.ex:22: String.Chars.to_string/1
    (elixir 1.14.3) lib/uri.ex:153: URI.encode_kv_pair/2
    (elixir 1.14.3) lib/enum.ex:1755: anonymous fn/2 in Enum.map_join/3
    (elixir 1.14.3) lib/enum.ex:4289: Enum.map_intersperse_list/3
    (elixir 1.14.3) lib/enum.ex:1755: Enum.map_join/3
    iex:2: (file)
```

After this PR:
```elixir
iex(1)> %{"filter" => %{"car" => %{"make" => "honda", "model" => "civic"}}} |> JSONAPI.Utils.List.to_list_of_query_string_components() |> URI.encode_query()
"filter%5Bcar%5D%5Bmake%5D=honda&filter%5Bcar%5D%5Bmodel%5D=civic"
```