### PR TITLE
Add options to transform field keys non-recursively (#132)

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Transforming fields requires two steps:
 
    ```elixir
    config :jsonapi,
-     field_transformation: :camelize # or dasherize
+     field_transformation: :camelize # or :dasherize, :camelize_shallow, or :dasherize_shallow
    ```
 
 2. Underscoring _incoming_ params (both query and body) requires you add the
@@ -215,7 +215,8 @@ config :jsonapi,
   `:camelize`. JSON:API v1.0 recommended using a dash (e.g.
   `"favorite-color": blue`). If your API uses dashed fields, set this value to
   `:dasherize`. If your API uses underscores (e.g. `"favorite_color": "red"`)
-  set to `:underscore`.
+  set to `:underscore`. To transform only the top-level field keys,  use
+  `:camelize_shallow` or `:dasherize_shallow`.
 - **remove_links**. `links` data can optionally be removed from the payload via
   setting the configuration above to `true`. Defaults to `false`.
 - **json_library**. Defaults to [Jason](https://hex.pm/packages/jason).

--- a/lib/jsonapi/plugs/query_parser.ex
+++ b/lib/jsonapi/plugs/query_parser.ex
@@ -282,15 +282,15 @@ defmodule JSONAPI.QueryParser do
   @spec get_view_for_type(module(), String.t()) :: module() | no_return()
   def get_view_for_type(view, type) do
     case Enum.find(view.relationships(), fn relationship ->
-           is_field_valid_for_relationship(relationship, type)
+           field_valid_for_relationship?(relationship, type)
          end) do
       {_, view} -> view
       nil -> raise_invalid_field_names(type, view.type())
     end
   end
 
-  @spec is_field_valid_for_relationship({atom(), module()}, String.t()) :: boolean()
-  defp is_field_valid_for_relationship({key, view}, expected_type) do
+  @spec field_valid_for_relationship?({atom(), module()}, String.t()) :: boolean()
+  defp field_valid_for_relationship?({key, view}, expected_type) do
     cond do
       view.type == expected_type ->
         true

--- a/lib/jsonapi/serializer.ex
+++ b/lib/jsonapi/serializer.ex
@@ -302,6 +302,8 @@ defmodule JSONAPI.Serializer do
     case Utils.String.field_transformation() do
       :camelize -> Utils.String.expand_fields(fields, &Utils.String.camelize/1)
       :dasherize -> Utils.String.expand_fields(fields, &Utils.String.dasherize/1)
+      :camelize_shallow -> Utils.String.expand_root_keys(fields, &Utils.String.camelize/1)
+      :dasherize_shallow -> Utils.String.expand_root_keys(fields, &Utils.String.dasherize/1)
       _ -> fields
     end
   end

--- a/lib/jsonapi/utils/data_to_params.ex
+++ b/lib/jsonapi/utils/data_to_params.ex
@@ -110,7 +110,9 @@ defmodule JSONAPI.Utils.DataToParams do
   defp transform_fields(fields) do
     case JString.field_transformation() do
       :camelize -> JString.expand_fields(fields, &JString.camelize/1)
+      :camelize_shallow -> JString.expand_fields(fields, &JString.camelize/1)
       :dasherize -> JString.expand_fields(fields, &JString.dasherize/1)
+      :dasherize_shallow -> JString.expand_fields(fields, &JString.dasherize/1)
       _ -> fields
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,6 @@ defmodule JSONAPI.Mixfile do
   end
 
   # Use Phoenix compiler depending on environment.
-  defp compilers(:test), do: [:phoenix] ++ Mix.compilers()
   defp compilers(_), do: Mix.compilers()
 
   # Specifies which paths to compile per environment.


### PR DESCRIPTION
Following up on [this discussion](https://github.com/beam-community/jsonapi/issues/132#issuecomment-1928563844).

This adds two new values for the config option `transform_fields`:

- `camelize_shallow`: Like `camelize`, but only affects the relationship and attribute keys, not their values.
- `dasherize_shallow`: Like `dasherize`, but only affects the relationship and attribute keys, not their values.

Some users may have views with fields that are maps, and don't want the map's keys dasherized or camelized. The new config values allow these users to use the `transform_fields` option to transform only the field names, but not the values.

Feedback is requested. I don't really like the config value names—preferably we can think of something better. If this seems like the right direction, I'll continue to update the documentation.