### PR TITLE
Transform relationship keys with shallow field transformation options (#314)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## NEXT
 ...
 
+## 1.7.1 (2024-02-23)
+* Transform relationship keys with shallow field transformation options (#314) by @protestContest in https://github.com/beam-community/jsonapi/pull/315
+
+**Full Changelog**: https://github.com/beam-community/jsonapi/compare/1.7.0...1.7.1
+
 ## 1.7.0 (2024-02-15)
 
 ## What's Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ...
 
 ## 1.7.1 (2024-02-23)
+* Fix bug where underscore/dasherize misses single characters by @protestContest in https://github.com/beam-community/jsonapi/pull/316
 * Transform relationship keys with shallow field transformation options (#314) by @protestContest in https://github.com/beam-community/jsonapi/pull/315
 
 **Full Changelog**: https://github.com/beam-community/jsonapi/compare/1.7.0...1.7.1

--- a/lib/jsonapi/utils/string.ex
+++ b/lib/jsonapi/utils/string.ex
@@ -267,6 +267,10 @@ defmodule JSONAPI.Utils.String do
     end)
   end
 
+  def expand_root_keys(key, fun) when is_binary(key) or is_atom(key) do
+    fun.(key)
+  end
+
   def expand_root_keys(value, _fun), do: expand_fields(value, &to_string/1)
 
   defp maybe_expand_fields(values, fun) when is_list(values) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule JSONAPI.Mixfile do
   def project do
     [
       app: :jsonapi,
-      version: "1.7.0",
+      version: "1.7.1",
       package: package(),
       compilers: compilers(Mix.env()),
       description: description(),

--- a/test/jsonapi/serializer_test.exs
+++ b/test/jsonapi/serializer_test.exs
@@ -667,11 +667,14 @@ defmodule JSONAPI.SerializerTest do
       encoded = Serializer.serialize(PostView, data, nil)
 
       attributes = encoded[:data][:attributes]
+      relationships = encoded[:data][:relationships]
       included = encoded[:included]
 
       assert attributes["full-description"] == data[:full_description]
       assert attributes["body"]["data_attr"] == "foo"
       assert attributes["inserted-at"] == data[:inserted_at]
+
+      assert Map.has_key?(relationships, "best-comments")
 
       author = Enum.find(included, &(&1[:type] == "user" && &1[:id] == "2"))
       assert author != nil


### PR DESCRIPTION
Closes #314.

This makes the name of `expand_root_keys/2` make less sense, so I'm open to alternative suggestions.