### PR TITLE
fix: [#334] Fix incorrect ordering of serialized lists

### DIFF
--- a/test/jsonapi/serializer_test.exs
+++ b/test/jsonapi/serializer_test.exs
@@ -277,6 +277,26 @@ defmodule JSONAPI.SerializerTest do
     assert Enum.count(encoded[:included]) == 4
   end
 
+  test "serialize keeps the order of a list" do
+    data1 = %{id: 1}
+    data2 = %{id: 2}
+    data3 = %{id: 3}
+
+    data_list = [data1, data2, data3]
+
+    conn = Plug.Conn.fetch_query_params(%Plug.Conn{})
+
+    encoded = Serializer.serialize(PostView, data_list, conn)
+
+    assert %{
+             data: [
+               %{id: "1"},
+               %{id: "2"},
+               %{id: "3"}
+             ]
+           } = encoded
+  end
+
   test "serialize handles an empty relationship" do
     data = %{
       id: 1,


### PR DESCRIPTION
A change introduced in `JSONAPI.Serializer` [here](https://github.com/beam-community/jsonapi/compare/1.7.1...v1.8.0#diff-a93b54749b1587f721f6b1b699cfe8e56134c39b70e5b8245a72c71ab550229fR53) (and a couple nearby spots) incorrectly orders a list response.

This fixes the list reversal, or reverts it in some places. List concatenation should be efficient enough in this instance.

Closes https://github.com/beam-community/jsonapi/issues/334