### PR TITLE
fix: Compiler warning for zero-arity fields function call

### DIFF
--- a/lib/jsonapi/plugs/query_parser.ex
+++ b/lib/jsonapi/plugs/query_parser.ex
@@ -279,7 +279,7 @@ defmodule JSONAPI.QueryParser do
     if type == view.type() do
       view.fields()
     else
-      get_view_for_type(view, type).fields
+      get_view_for_type(view, type).fields()
     end
   end
 


### PR DESCRIPTION
Hey, this PR is a follow up on https://github.com/beam-community/jsonapi/pull/335, fixing a remaining compiler warning.

Thanks!