### PR TITLE
fix: camelize when prefix is camelized already

### DIFF
--- a/lib/jsonapi/utils/string.ex
+++ b/lib/jsonapi/utils/string.ex
@@ -109,6 +109,12 @@ defmodule JSONAPI.Utils.String do
       iex> camelize("alreadyCamelized")
       "alreadyCamelized"
 
+      iex> camelize("alreadyCamelized-id")
+      "alreadyCamelizedId"
+
+      iex> camelize("alreadyCamelized_id")
+      "alreadyCamelizedId"
+
   """
   @spec camelize(atom) :: String.t()
   def camelize(value) when is_atom(value) do
@@ -121,28 +127,25 @@ defmodule JSONAPI.Utils.String do
   def camelize(value) when value == "", do: value
 
   def camelize(value) when is_binary(value) do
-    with words <-
-           Regex.split(
-             ~r{(?<=[a-zA-Z0-9])[-_](?=[a-zA-Z0-9])},
-             to_string(value),
-             trim: true
-           ) do
-      case words do
-        # If there is only one word, leave it as-is
-        [word] ->
-          word
+    case Regex.split(
+           ~r{(?<=[a-zA-Z0-9])[-_](?=[a-zA-Z0-9])},
+           to_string(value),
+           trim: true
+         ) do
+      # If there is only one word, leave it as-is
+      [word] ->
+        word
 
-        # If there are multiple words, perform the camelizing
-        [h | t] ->
-          Enum.join([String.downcase(h) | camelize_list(t)])
-      end
+      # If there are multiple words, perform the camelizing
+      [h | t] ->
+        Enum.join([h | camelize_list(t)])
     end
   end
 
   defp camelize_list([]), do: []
 
   defp camelize_list([h | t]) do
-    [String.capitalize(h)] ++ camelize_list(t)
+    [String.capitalize(h) | camelize_list(t)]
   end
 
   @doc """

--- a/lib/jsonapi/utils/string.ex
+++ b/lib/jsonapi/utils/string.ex
@@ -115,6 +115,9 @@ defmodule JSONAPI.Utils.String do
       iex> camelize("alreadyCamelized_id")
       "alreadyCamelizedId"
 
+      iex> camelize("PascalLambda_id")
+      "pascalLambdaId"
+
   """
   @spec camelize(atom) :: String.t()
   def camelize(value) when is_atom(value) do
@@ -138,7 +141,9 @@ defmodule JSONAPI.Utils.String do
 
       # If there are multiple words, perform the camelizing
       [h | t] ->
-        Enum.join([h | camelize_list(t)])
+        {first_character, rest_word} = String.split_at(h, 1)
+        first_word = String.downcase(first_character) <> rest_word
+        Enum.join([first_word | camelize_list(t)])
     end
   end
 


### PR DESCRIPTION
This PR fixes a problem when payload relationship is already camelized:

In the POST, when you receive as payload:

```elixir
%{
  type: "example-resource",
  attributes: %{...},
  relationships: %{
    generalManagerProfile: %{data: %{id: manager_id, type: "profiles"}}
  }
}
```

params will resolve to:

```elixir
%{"generalmanagerprofileId" => 139981}
```

with this fix, it resolves correctly to `generalManagerProfileId`, and with the `UnderscoreParameters` plug, becomes `general_manager_profile_id`.