### PR TITLE
add backwards compatible polymorphic resource support

### DIFF
--- a/lib/jsonapi/serializer.ex
+++ b/lib/jsonapi/serializer.ex
@@ -62,7 +62,7 @@ defmodule JSONAPI.Serializer do
 
     encoded_data = %{
       id: view.id(data),
-      type: view.type(),
+      type: view.resource_type(data),
       attributes: transform_fields(view.attributes(data, conn)),
       relationships: %{}
     }
@@ -255,7 +255,7 @@ defmodule JSONAPI.Serializer do
 
   def encode_rel_data(view, data) do
     %{
-      type: view.type(),
+      type: view.resource_type(data),
       id: view.id(data)
     }
   end

--- a/test/jsonapi/serializer_test.exs
+++ b/test/jsonapi/serializer_test.exs
@@ -13,7 +13,8 @@ defmodule JSONAPI.SerializerTest do
     def relationships do
       [
         author: {JSONAPI.SerializerTest.UserView, :include},
-        best_comments: {JSONAPI.SerializerTest.CommentView, :include}
+        best_comments: {JSONAPI.SerializerTest.CommentView, :include},
+        polymorphics: {JSONAPI.SerializerTest.PolymorphicView, :include}
       ]
     end
   end
@@ -183,6 +184,38 @@ defmodule JSONAPI.SerializerTest do
     end
   end
 
+  defmodule PolymorphicDataOne do
+    defstruct [:id, :some_field]
+  end
+
+  defmodule PolymorphicDataTwo do
+    defstruct [:id, :some_other_field]
+  end
+
+  defmodule PolymorphicView do
+    use JSONAPI.View, polymorphic_resource: true
+
+    def polymorphic_type(data) do
+      case data do
+        %PolymorphicDataOne{} ->
+          "polymorphic_data_one"
+
+        %PolymorphicDataTwo{} ->
+          "polymorphic_data_one"
+      end
+    end
+
+    def polymorphic_fields(data) do
+      case data do
+        %PolymorphicDataOne{} ->
+          [:some_field]
+
+        %PolymorphicDataTwo{} ->
+          [:some_other_field]
+      end
+    end
+  end
+
   setup do
     Application.put_env(:jsonapi, :field_transformation, :underscore)
 
@@ -219,6 +252,10 @@ defmodule JSONAPI.SerializerTest do
       best_comments: [
         %{id: 5, text: "greatest comment ever", user: %{id: 4, username: "jack"}},
         %{id: 6, text: "not so great", user: %{id: 2, username: "jason"}}
+      ],
+      polymorphic: [
+        %PolymorphicDataOne{id: 1, some_field: "foo"},
+        %PolymorphicDataTwo{id: 2, some_other_field: "foo"}
       ]
     }
 
@@ -842,7 +879,8 @@ defmodule JSONAPI.SerializerTest do
 
     assert configs == [
              {:author, :author, JSONAPI.SerializerTest.UserView, true},
-             {:best_comments, :best_comments, JSONAPI.SerializerTest.CommentView, true}
+             {:best_comments, :best_comments, JSONAPI.SerializerTest.CommentView, true},
+             {:polymorphics, :polymorphics, JSONAPI.SerializerTest.PolymorphicView, true}
            ]
   end
 

--- a/test/jsonapi/view_test.exs
+++ b/test/jsonapi/view_test.exs
@@ -55,6 +55,38 @@ defmodule JSONAPI.ViewTest do
     def get_field(field, _data, _conn), do: "#{field}!"
   end
 
+  defmodule PolymorphicDataOne do
+    defstruct [:some_field]
+  end
+
+  defmodule PolymorphicDataTwo do
+    defstruct [:some_other_field]
+  end
+
+  defmodule PolymorphicView do
+    use JSONAPI.View, polymorphic_resource: true
+
+    def polymorphic_type(data) do
+      case data do
+        %PolymorphicDataOne{} ->
+          "polymorphic_data_one"
+
+        %PolymorphicDataTwo{} ->
+          "polymorphic_data_one"
+      end
+    end
+
+    def polymorphic_fields(data) do
+      case data do
+        %PolymorphicDataOne{} ->
+          [:some_field]
+
+        %PolymorphicDataTwo{} ->
+          [:some_other_field]
+      end
+    end
+  end
+
   setup do
     Application.put_env(:jsonapi, :field_transformation, :underscore)
     Application.put_env(:jsonapi, :namespace, "/other-api")
@@ -69,6 +101,20 @@ defmodule JSONAPI.ViewTest do
 
   test "type/0 when specified via using macro" do
     assert PostView.type() == "posts"
+  end
+
+  describe "resource_type/1" do
+    test "equals result of type/0 if resource is not polymorphic" do
+      assert PostView.type() == PostView.resource_type(%{})
+    end
+
+    test "equals result of polymorphic_type/1 if resource is polymorphic" do
+      assert PolymorphicView.polymorphic_type(%PolymorphicDataOne{}) ==
+               PolymorphicView.resource_type(%PolymorphicDataOne{})
+
+      assert PolymorphicView.polymorphic_type(%PolymorphicDataTwo{}) ==
+               PolymorphicView.resource_type(%PolymorphicDataTwo{})
+    end
   end
 
   describe "namespace/0" do
@@ -313,5 +359,14 @@ defmodule JSONAPI.ViewTest do
              static_field: "static_field!",
              static_fun: "static_fun/2"
            } == DynamicView.attributes(data, conn)
+  end
+
+  test "attributes/2 can return polymorphic fields" do
+    data = %PolymorphicDataTwo{some_other_field: "foo"}
+    conn = %Plug.Conn{assigns: %{jsonapi_query: %JSONAPI.Config{}}}
+
+    assert %{
+             some_other_field: "foo"
+           } == PolymorphicView.attributes(data, conn)
   end
 end


### PR DESCRIPTION
Hey there,
I tried my best to add support for polymorphic resources.
The idea is to allow the user to infer resource specifics from the given data.
Currently this only allows `type` and `fields` to be polymorphic. I will probably implement relationships as well.

Additionally I only tested it to work as a relation with an api endpoint of its own - quite frankly there are some things that are not possible: 
The `QueryParser` fetches `view.fields()` at a moment where no data is present, thus inference is not possible.

This is my first time really working with a behaviour, my approach on implementing a backwards compatible solution felt a bit clunky, so any feedback is very welcome.  :)