### PR TITLE
fix: bug with DataToParams include processing expecting more 'data' keys than the spec calls for

### DIFF
--- a/lib/jsonapi/utils/data_to_params.ex
+++ b/lib/jsonapi/utils/data_to_params.ex
@@ -94,8 +94,8 @@ defmodule JSONAPI.Utils.DataToParams do
 
   defp process_included(%{"included" => included} = incoming) do
     included
-    |> Enum.reduce(incoming, fn %{"data" => %{"type" => type}} = params, acc ->
-      flattened = process(params)
+    |> Enum.reduce(incoming, fn %{"type" => type} = params, acc ->
+      flattened = process(%{"data" => params})
 
       case Map.has_key?(acc, type) do
         false -> Map.put(acc, type, [flattened])

--- a/test/utils/data_to_params_test.exs
+++ b/test/utils/data_to_params_test.exs
@@ -106,13 +106,11 @@ defmodule JSONAPI.DataToParamsTest do
       },
       "included" => [
         %{
-          "data" => %{
-            "attributes" => %{
-              "name" => "Tara"
-            },
-            "id" => "234",
-            "type" => "friend"
-          }
+          "attributes" => %{
+            "name" => "Tara"
+          },
+          "id" => "234",
+          "type" => "friend"
         }
       ]
     }
@@ -144,42 +142,36 @@ defmodule JSONAPI.DataToParamsTest do
       },
       "included" => [
         %{
-          "data" => %{
-            "id" => "234",
-            "type" => "friend",
-            "attributes" => %{
-              "name" => "Tara"
-            },
-            "relationships" => %{
-              "baz" => %{
-                "data" => %{
-                  "id" => "2",
-                  "type" => "baz"
-                }
-              },
-              "boo" => %{
-                "data" => nil
+          "id" => "234",
+          "type" => "friend",
+          "attributes" => %{
+            "name" => "Tara"
+          },
+          "relationships" => %{
+            "baz" => %{
+              "data" => %{
+                "id" => "2",
+                "type" => "baz"
               }
+            },
+            "boo" => %{
+              "data" => nil
             }
           }
         },
         %{
-          "data" => %{
-            "attributes" => %{
-              "name" => "Wild Bill"
-            },
-            "id" => "0012",
-            "type" => "friend"
-          }
+          "attributes" => %{
+            "name" => "Wild Bill"
+          },
+          "id" => "0012",
+          "type" => "friend"
         },
         %{
-          "data" => %{
-            "attributes" => %{
-              "title" => "Sr"
-            },
-            "id" => "456",
-            "type" => "organization"
-          }
+          "attributes" => %{
+            "title" => "Sr"
+          },
+          "id" => "456",
+          "type" => "organization"
         }
       ]
     }


### PR DESCRIPTION
The JSON:API specification says that the `"included"` key in a response will contain an array of "resource objects" which is to say JSON objects containing `id`, `type`, etc. Prior to this PR, the `DataToParams` module expected `"included"` to contain an array of documents, ostensibly (rooted with `"data"` keys). This PR fixes that handling. The result can be seen clearly in the fixes to the test inputs.