### PR TITLE
feat: support nested filtering in the query parser

### DIFF
--- a/lib/jsonapi/utils/include_tree.ex
+++ b/lib/jsonapi/utils/include_tree.ex
@@ -3,6 +3,21 @@ defmodule JSONAPI.Utils.IncludeTree do
   Internal utility for building trees of resource relationships
   """
 
+  def deep_merge(acc, []), do: acc
+
+  def deep_merge(acc, [{key, val} | tail]) do
+    acc
+    |> Keyword.update(
+      key,
+      val,
+      fn
+        [_first | _rest] = old_val -> deep_merge(old_val, val)
+        old_val -> Keyword.put([], old_val, val)
+      end
+    )
+    |> deep_merge(tail)
+  end
+
   @spec put_as_tree(term(), term(), term()) :: term()
   def put_as_tree(acc, items, val) do
     [head | tail] = Enum.reverse(items)

--- a/lib/jsonapi/utils/include_tree.ex
+++ b/lib/jsonapi/utils/include_tree.ex
@@ -3,6 +3,7 @@ defmodule JSONAPI.Utils.IncludeTree do
   Internal utility for building trees of resource relationships
   """
 
+  @spec deep_merge(Keyword.t(), Keyword.t()) :: Keyword.t()
   def deep_merge(acc, []), do: acc
 
   def deep_merge(acc, [{key, val} | tail]) do
@@ -11,8 +12,8 @@ defmodule JSONAPI.Utils.IncludeTree do
       key,
       val,
       fn
-        [_first | _rest] = old_val -> deep_merge(old_val, val)
-        old_val -> Keyword.put([], old_val, val)
+        [_first | _rest] = old_val when is_list(val) -> deep_merge(old_val, val)
+        _ -> val
       end
     )
     |> deep_merge(tail)

--- a/test/jsonapi/plugs/query_parser_test.exs
+++ b/test/jsonapi/plugs/query_parser_test.exs
@@ -64,10 +64,23 @@ defmodule JSONAPI.QueryParserTest do
     end
   end
 
-  test "parse_filter/2 turns filters key/val pairs" do
+  test "parse_filter/2 returns filters key/val pairs" do
     config = struct(Config, opts: [filter: ~w(name)], view: MyView)
     filter = parse_filter(config, %{"name" => "jason"}).filter
     assert filter[:name] == "jason"
+  end
+
+  test "parse_filter/2 handles nested filters" do
+    config = struct(Config, opts: [filter: ~w(author.username)], view: MyView)
+    filter = parse_filter(config, %{"author.username" => "jason"}).filter
+    assert filter[:author][:username] == "jason"
+  end
+
+  test "parse_filter/2 handles nested filters with overlap" do
+    config = struct(Config, opts: [filter: ~w(author.username author.id)], view: MyView)
+    filter = parse_filter(config, %{"author.username" => "jason", "author.id" => "123"}).filter
+    assert filter[:author][:username] == "jason"
+    assert filter[:author][:id] == "123"
   end
 
   test "parse_filter/2 raises on invalid filters" do
@@ -87,6 +100,12 @@ defmodule JSONAPI.QueryParserTest do
     assert parse_include(config, "best_friends").include == [:best_friends]
     assert parse_include(config, "author.top-posts").include == [author: :top_posts]
     assert parse_include(config, "").include == []
+  end
+
+  test "parse_include/2 succeds given valid nested include specified in allowed list" do
+    config = struct(Config, view: MyView, opts: [include: ~w(comments.user)])
+
+    assert parse_include(config, "comments.user").include == [comments: :user]
   end
 
   test "parse_include/2 errors with invalid includes" do

--- a/test/utils/include_tree_test.exs
+++ b/test/utils/include_tree_test.exs
@@ -13,4 +13,11 @@ defmodule JSONAPI.IncludeTreeTest do
     # the other direction
     assert [hi: "there", other: "thing"] = deep_merge([hi: [hello: "there"]], other: "thing", hi: "there")
   end
+
+  test "deep_merge/2 handles string/string conflict by choosing second value" do
+    # one direction
+    assert [hi: "there"] = deep_merge([hi: "hello"], hi: "there")
+    # the other direction
+    assert [hi: "hello"] = deep_merge([hi: "there"], hi: "hello")
+  end
 end

--- a/test/utils/include_tree_test.exs
+++ b/test/utils/include_tree_test.exs
@@ -6,4 +6,11 @@ defmodule JSONAPI.IncludeTreeTest do
     items = [:test, :the, :path]
     assert put_as_tree([], items, :boo) == [test: [the: [path: :boo]]]
   end
+
+  test "deep_merge/2 handles string/keyword conflict by choosing second value" do
+    # one direction
+    assert [other: "thing", hi: [hello: "there"]] = deep_merge([other: "thing", hi: "there"], hi: [hello: "there"])
+    # the other direction
+    assert [hi: "there", other: "thing"] = deep_merge([hi: [hello: "there"]], other: "thing", hi: "there")
+  end
 end


### PR DESCRIPTION
The project I am working on allows filtering of related resource fields (e.g. `user.name` meaning the `name` field of the `user` relationship). I realized when updating to the latest version of this library that such filters are not supported; it was actually a Credo PR that resulted in a chore update that broke things because a call to `String.to_atom/1` became a call to `String.to_existing_atom/1` in a place where the string `"user.name"` might be the input.

This PR fixes that in a backwards compatible way. It supports filtering on related resource properties by creating deeper Keyword Lists similar to those output by the include parser (which already supports nested includes). I am not confident Keyword Lists would be the best way to go for this nested filter structure if we were coming at it from scratch and could choose a Map, but this is backwards compatible and quite functional.

This PR also renames a two private functions to clarify the difference between "validity" of a filter or include (represents a real option as determined by a view) vs. "allowed" (is specified in the allow-list passed to the QueryParser plug). That is, `check_filter_validity!/3` becomes `check_filter_allowed!/3` and `check_include_validity!/3` becomes `check_include_allowed!/3`.

If this feels like a reasonable direction, it isn't lost on me that `IncludeTree` may no longer be the best name for the module holding helpers that are now useful for both includes and filters, but I honestly wasn't sure if it was worth it to rename the module to something more generic for now.