### PR TITLE
fix: use `erlef/setup-beam` in github actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,9 +31,13 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Elixir
-        uses: stordco/actions-elixir/setup@v1
+        uses: erlef/setup-beam@v1
         with:
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          elixir-version: "1.19"
+          otp-version: "27.0"
+
+      - run: mix deps.get
 
       - name: Credo
         run: mix credo --strict
@@ -46,9 +50,13 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Elixir
-        uses: stordco/actions-elixir/setup@v1
+        uses: erlef/setup-beam@v1
         with:
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          elixir-version: "1.19"
+          otp-version: "27.0"
+
+      - run: mix deps.get
 
       - name: Unused
         run: mix deps.unlock --check-unused
@@ -61,9 +69,13 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Elixir
-        uses: stordco/actions-elixir/setup@v1
+        uses: erlef/setup-beam@v1
         with:
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          elixir-version: "1.19"
+          otp-version: "27.0"
+
+      - run: mix deps.get
 
       - name: Dialyzer
         run: mix dialyzer --format github
@@ -76,9 +88,13 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Elixir
-        uses: stordco/actions-elixir/setup@v1
+        uses: erlef/setup-beam@v1
         with:
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          elixir-version: "1.19"
+          otp-version: "27.0"
+
+      - run: mix deps.get
 
       - name: Format
         run: mix format --check-formatted
@@ -96,11 +112,13 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Elixir
-        uses: stordco/actions-elixir/setup@v1
+        uses: erlef/setup-beam@v1
         with:
           elixir-version: ${{ matrix.versions.elixir }}
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           otp-version: ${{ matrix.versions.otp }}
+
+      - run: mix deps.get
 
       - name: Compile
         run: mix compile --warnings-as-errors

--- a/.github/workflows/common-config.yaml
+++ b/.github/workflows/common-config.yaml
@@ -35,7 +35,7 @@ jobs:
           node-version: 20
 
       - name: Setup Elixir
-        uses: stordco/actions-elixir/setup@v1
+        uses: erlef/setup-beam@v1
         with:
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           elixir-version: "1.19"

--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -21,9 +21,13 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Elixir
-        uses: stordco/actions-elixir/setup@v1
+        uses: erlef/setup-beam@v1
         with:
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          elixir-version: "1.19"
+          otp-version: "27.0"
+
+      - run: mix deps.get
 
       - name: Compile
         run: mix compile --docs

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -18,9 +18,13 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Elixir
-        uses: stordco/actions-elixir/setup@v1
+        uses: erlef/setup-beam@v1
         with:
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          elixir-version: "1.19"
+          otp-version: "27.0"
+
+      - run: mix deps.get
 
       - name: Publish Docs
         run: mix hex.publish docs --yes


### PR DESCRIPTION
This PR is intended to fix the broken CI steps blocking release of the next version of jsonapi. The `stordco/elixir-actions` repo is no longer available, so this PR switches those actions to use `erlef/setup-beam` instead.