### PR TITLE
fix: dialyzer and deprecation warnings

### DIFF
--- a/lib/jsonapi/view.ex
+++ b/lib/jsonapi/view.ex
@@ -387,28 +387,22 @@ defmodule JSONAPI.View do
       def visible_relationships(data, conn),
         do: View.visible_relationships(__MODULE__, data, conn)
 
-      def resource_fields(data) do
-        if @polymorphic_resource? do
-          polymorphic_fields(data)
-        else
-          fields()
-        end
+      if @polymorphic_resource? do
+        def resource_fields(data), do: polymorphic_fields(data)
+      else
+        def resource_fields(_data), do: fields()
       end
 
-      def resource_type(data) do
-        if @polymorphic_resource? do
-          polymorphic_type(data)
-        else
-          type()
-        end
+      if @polymorphic_resource? do
+        def resource_type(data), do: polymorphic_type(data)
+      else
+        def resource_type(_data), do: type()
       end
 
-      def resource_relationships(data) do
-        if @polymorphic_resource? do
-          polymorphic_relationships(data)
-        else
-          relationships()
-        end
+      if @polymorphic_resource? do
+        def resource_relationships(data), do: polymorphic_relationships(data)
+      else
+        def resource_relationships(_data), do: relationships()
       end
 
       @doc """
@@ -421,12 +415,10 @@ defmodule JSONAPI.View do
       to operate from the QueryParser Plug.
       """
       @spec valid_attrs_and_rels() :: [atom()]
-      def valid_attrs_and_rels do
-        if @polymorphic_resource? do
-          []
-        else
-          fields() ++ Enum.map(relationships(), fn {name, _} -> name end)
-        end
+      if @polymorphic_resource? do
+        def valid_attrs_and_rels, do: []
+      else
+        def valid_attrs_and_rels, do: fields() ++ Enum.map(relationships(), fn {name, _} -> name end)
       end
 
       defoverridable View

--- a/test/jsonapi/plugs/content_type_negotiation_test.exs
+++ b/test/jsonapi/plugs/content_type_negotiation_test.exs
@@ -1,8 +1,8 @@
 defmodule JSONAPI.ContentTypeNegotiationTest do
   use ExUnit.Case
-  use Plug.Test
 
   import JSONAPI, only: [mime_type: 0]
+  import Plug.Test
 
   alias JSONAPI.ContentTypeNegotiation
 

--- a/test/jsonapi/plugs/deserializer_test.exs
+++ b/test/jsonapi/plugs/deserializer_test.exs
@@ -1,6 +1,7 @@
 defmodule JSONAPI.DeserializerTest do
   use ExUnit.Case
-  use Plug.Test
+
+  import Plug.Conn
 
   @ct JSONAPI.mime_type()
 

--- a/test/jsonapi/plugs/format_required_test.exs
+++ b/test/jsonapi/plugs/format_required_test.exs
@@ -1,6 +1,7 @@
 defmodule JSONAPI.FormatRequiredTest do
   use ExUnit.Case
-  use Plug.Test
+
+  import Plug.Test
 
   alias JSONAPI.FormatRequired
 

--- a/test/jsonapi/plugs/id_required_test.exs
+++ b/test/jsonapi/plugs/id_required_test.exs
@@ -1,6 +1,7 @@
 defmodule JSONAPI.IdRequiredTest do
   use ExUnit.Case
-  use Plug.Test
+
+  import Plug.Test
 
   alias JSONAPI.IdRequired
 

--- a/test/jsonapi/plugs/response_content_type_test.exs
+++ b/test/jsonapi/plugs/response_content_type_test.exs
@@ -1,6 +1,7 @@
 defmodule JSONAPI.ResponseContentTypeTest do
   use ExUnit.Case
-  use Plug.Test
+
+  import Plug.{Conn, Test}
 
   alias JSONAPI.ResponseContentType
 

--- a/test/jsonapi/plugs/underscore_parameters_test.exs
+++ b/test/jsonapi/plugs/underscore_parameters_test.exs
@@ -1,6 +1,7 @@
 defmodule JSONAPI.UnderscoreParametersTest do
   use ExUnit.Case, async: true
-  use Plug.Test
+
+  import Plug.{Conn, Test}
 
   alias JSONAPI.UnderscoreParameters
 

--- a/test/jsonapi_test.exs
+++ b/test/jsonapi_test.exs
@@ -1,6 +1,7 @@
 defmodule JSONAPITest do
   use ExUnit.Case
-  use Plug.Test
+
+  import Plug.Test
 
   @default_data %{
     id: 1,


### PR DESCRIPTION
Fixes Plug warning:
> warning: use Plug.Test is deprecated. Please use `import Plug.Test` and `impor
t Plug.Conn` directly instead.

Fixes Dialyzer warning:
> Diagnostics:
> 1. The pattern can never match the type.
>   
>   Pattern:
>   false
>   
>   Type:
>   true