### PR TITLE
fix: fixes `QueryParser` parsing of dasherized/camelized filter keys

### DIFF
--- a/lib/jsonapi/plugs/query_parser.ex
+++ b/lib/jsonapi/plugs/query_parser.ex
@@ -119,6 +119,7 @@ defmodule JSONAPI.QueryParser do
     opts_filter = Keyword.get(opts, :filter, [])
 
     Enum.reduce(filter, config, fn {key, val}, acc ->
+      key = underscore(key)
       check_filter_allowed!(opts_filter, key, config)
 
       keys = key |> String.split(".") |> Enum.map(&String.to_existing_atom/1)

--- a/lib/jsonapi/plugs/query_parser.ex
+++ b/lib/jsonapi/plugs/query_parser.ex
@@ -65,15 +65,6 @@ defmodule JSONAPI.QueryParser do
     * `:view` - The JSONAPI View which is the basis for this plug.
     * `:sort` - List of atoms which define which fields can be sorted on.
     * `:filter` - List of atoms which define which fields can be filtered on.
-
-  ## Dasherized Fields
-
-  Note that if your API is returning dasherized fields (e.g. `"dog-breed": "Corgi"`)
-  we recommend that you include the `JSONAPI.UnderscoreParameters` Plug in your
-  API's pipeline with the `replace_query_params` option set to `true`. This will
-  underscore fields for easier operations in your code.
-
-  For more details please see `JSONAPI.UnderscoreParameters`.
   """
   @behaviour Plug
 

--- a/test/jsonapi/plugs/query_parser_test.exs
+++ b/test/jsonapi/plugs/query_parser_test.exs
@@ -80,7 +80,7 @@ defmodule JSONAPI.QueryParserTest do
 
   test "parse_filter/2 handles nested filters two deep" do
     config = struct(Config, opts: [filter: ~w(author.top_posts.text)], view: MyView)
-    filter = parse_filter(config, %{"author.top_posts.text" => "some post"}).filter
+    filter = parse_filter(config, %{"author.topPosts.text" => "some post"}).filter
     assert filter[:author][:top_posts][:text] == "some post"
   end
 


### PR DESCRIPTION
Analogous to #431 but for `filter`.

`QueryParser` is already automatically underscoring `fields`, `sort` and `include`, just missing `filter`.

Seems this would be the last fix needed to "close" [Standardize on underscoring query parameters #285](https://github.com/beam-community/jsonapi/issues/285).

---

Underscoring of `filter` keys is technically already supported by `UnderscoreParameters` plug, but it feels that this should work for anyone using `QueryParser` and not `UnderscoreParameters` plug.

I kind of agree with the following statement by @TylerPachal statement in #285 

> I think for version 2.0 of this library:

  > All of the query parameters should always be underscored. It should be done by the QueryParser module.
  >   The UnderscoreParameters module should go back to just doing the params, mostly undoing the work in https://github.com/beam-community/jsonapi/pull/282.